### PR TITLE
Updated Dependabot. 

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,6 +4,9 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "live"
+    allowed_updates:
+      - match:
+        update_type: "security"
     default_reviewers:
     - tomas-stefano
     - brenetic


### PR DESCRIPTION
Service is being replaced and does not require all dependency updates, only security ones.